### PR TITLE
support jinja 2.7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,8 +50,7 @@
         msg: cert_name is missing or empty for one or more hosts in a tunnel
       when: '"True" in failure'
 
-    - name: generate psks on first host
-      run_once: true
+    - name: generate psks
       no_log: true
       set_fact:
         __vpn_psks: |
@@ -76,28 +75,35 @@
           {% endfor %}
           {{ __vpn_psks }}
 
-    - name: set psks for all hosts
-      no_log: true
-      set_fact:
-        __vpn_psks: "{{ hostvars[hostvars.keys() | first]['__vpn_psks'] }}"
-
   delegate_to: localhost
   run_once: true
+
+# The run_once host might not be the first one in hostvars - we do not have
+# a good way to know which host in hostvars was the run_once, and it might
+# change (i.e. on python2 if a non-stable hash is used for the dict)
+# So, find the values for the first hostvars that has __vpn_psks set
+# and use that value.
+- name: set psks for hosts
+  no_log: true
+  vars:
+    __vpn_psk_hostvars: "{{ hostvars.values() | selectattr('__vpn_psks', 'defined') | first }}"
+  set_fact:
+    __vpn_psks: "{{ __vpn_psk_hostvars.__vpn_psks }}"
 
 - name: build tunnels
   vars:
     tunnels: |
-      {% set ns = namespace(unique_tunnels=[]) %}
+      {% set unique_tunnels = [] %}
       {% for tunnel in vpn_connections %}
       {%   if inventory_hostname in tunnel.hosts %}
       {%     for node in tunnel.hosts %}
       {%       if node != inventory_hostname %}
-      {%         set _ = ns.unique_tunnels.append(node) %}
+      {%         set _ = unique_tunnels.append(node) %}
       {%       endif %}
       {%     endfor %}
       {%   endif %}
       {% endfor %}
-      {{ ns.unique_tunnels | unique }}
+      {{ unique_tunnels | unique }}
   block:
     - name: create ipsec.conf files
       template:

--- a/templates/libreswan-host-to-host.secrets.j2
+++ b/templates/libreswan-host-to-host.secrets.j2
@@ -12,7 +12,7 @@
 {%             if tunnel.hosts[host] is mapping and 'hostname' in tunnel.hosts[host] %}
 {%               set host = tunnel.hosts[host].hostname %}
 {%             endif %}
-@{{ host }} @{{ otherhost }} : PSK {{ otherval['pre_shared_key'] }}
+@{{ host }} @{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
 {%           endif %}
 {%         endfor %}
 {%       endif %}

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -25,17 +25,17 @@
     - name: clean up files
       vars:
         tunnels: |
-          {% set ns = namespace(unique_tunnels=[]) %}
+          {% set unique_tunnels = [] %}
           {% for connection in vpn_connections | d([])%}
           {%   if inventory_hostname in connection.hosts %}
           {%     for node in connection.hosts %}
           {%       if node != inventory_hostname %}
-          {%         set _ = ns.unique_tunnels.append(node) %}
+          {%         set _ = unique_tunnels.append(node) %}
           {%       endif %}
           {%     endfor %}
           {%   endif %}
           {% endfor %}
-          {{ ns.unique_tunnels | unique }}
+          {{ unique_tunnels | unique }}
 
       block:
         - name: remove ipsec.conf files

--- a/tests/tests_host_to_host_cert.yml
+++ b/tests/tests_host_to_host_cert.yml
@@ -28,6 +28,10 @@
               {% endfor %}
               {{ vpn_connections }}
 
+        - name: Save certname for main host
+          set_fact:
+            __vpn_main_certname: "{{ vpn_connections[0]['hosts'][main_hostname]['cert_name'] }}"
+
         - name: Use vpn role
           include_role:
             name: linux-system-roles.vpn
@@ -68,7 +72,7 @@
             item.content | b64decode is not
             search('rightrsasigkey=%cert') or
             item.content | b64decode is not
-            search('leftcert=cert' + (num_hosts+1)|string)
+            search('leftcert=' + __vpn_main_certname)
           loop: '{{ __vpn_register_conf.results }}'
           loop_control:
             index_var: idx
@@ -88,7 +92,7 @@
           set_fact:
             __vpn_success: false
           when: >-
-            item.content | b64decode is not search('^@' + main_hostname + ' @host0' + (idx+1)|string + '\.local : RSA \"cert' + (num_hosts+1)|string + '\"')
+            item.content | b64decode is not search('^@' + main_hostname + ' @host0' + (idx+1)|string + '\.local : RSA \"' + __vpn_main_certname + '\"')
           loop: '{{ __vpn_register_secrets.results }}'
           loop_control:
             index_var: idx


### PR DESCRIPTION
do not use `namespace`
The run_once behavior is different when using python2/ansible28/jinja27
we are not guaranteed that the run_once host is the first host in
hostvars - so instead, find the hostvars value that has __vpn_psks
The mainhost is not guaranteed to be the last one - so save the
cert name assigned to it for use later to verify.
