### PR TITLE
Update conn naming scheme and leftid/rightid values

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ The user can define an authentication method to use at the tunnel level, however
 What operation, if any, should be done automatically at IPsec startup. Currently-accepted values are **add**, **ondemand**, **start**, and **ignore** (also the default, signifies no automatic startup operation).
 
 ### hosts
-Each key in this dictionary is the unique name of a host. If a host is listed here and is not part of the inventory list of hosts, it will be assumed that this host is not managed by our own inventory. In this case, the `hostname` parameter is required because it is necessary for setting up the local ends of such a tunnel. For each host key in this dictionary, the following host-specific parameters can be specified.  
+Each key in this dictionary is the unique name of a host. If a host is listed here and is not part of the inventory list of hosts, it will be assumed that this host is not managed by our own inventory. In this case, the `hostname` parameter is required because it is necessary for setting up the local ends of such a tunnel. 
+
+If the host key in the hosts list of your inventory is not the FQDN you want to use, you must use the `hostname` field under each host in this `vpn_connections` hosts dictionary to specify the actual FQDN or IP address you want the vpn role to use to set up the tunnel. If you do not specify `hostname`, then the role will use `ansible_host` if defined, or the host key in your hosts list if neither `ansible_host` nor `hostname` is defined. 
+
+For each host key in this dictionary, the following host-specific parameters can be specified.  
 
 | Parameter                         | Description                                                                                   | Type        | Required | Default                 | Libreswan Equivalent         |
 |-----------------------------------|-----------------------------------------------------------------------------------------------|:-----------:|:--------:|-------------------------|:----------------------------:|

--- a/templates/libreswan-host-to-host.conf.j2
+++ b/templates/libreswan-host-to-host.conf.j2
@@ -1,26 +1,18 @@
 #jinja2: lstrip_blocks: True
 {% for tunnel in vpn_connections %}
 {%   if item in tunnel.hosts %}
+{%     set otherhost = tunnel.hosts[item].hostname | d((hostvars[item] | d({})).ansible_host | d(item)) %}
 {%     for host in tunnel.hosts %}
 {%       if host == inventory_hostname or host == ansible_host %}
-{%         if tunnel.hosts[host] is mapping and 'hostname' in tunnel.hosts[host] %}
-{%           set host = tunnel.hosts[host].hostname %}
-{%         endif %}
-conn {{ (tunnel | json_query('name')) | ternary((tunnel.name | d('', true)) + '-', '') }}{{ host }}-to-{{ item }}
+{%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
+conn {{ (tunnel | json_query('name')) | ternary((tunnel.name | d('', true)) + '-', '') }}{{ host }}-to-{{ otherhost }}
   left={{ host }}
   leftid=@{{ host }}
 {%       endif %}
 {%     endfor %}
-{%     if tunnel.hosts[item] is mapping and 'hostname' in tunnel.hosts[item] %}
-  right={{ tunnel.hosts[item].hostname | d(item) }}
-{%       if tunnel.auth_method == 'psk' %}
-  rightid=@{{ tunnel.hosts[item].hostname | d(item) }}
-{%       endif %}
-{%     else %}
-  right={{ hostvars[item].ansible_host | d(item) }}
-{%       if tunnel.auth_method == 'psk' %}
-  rightid=@{{ hostvars[item].ansible_host | d(item) }}
-{%       endif %}
+  right={{ otherhost }}
+{%     if tunnel.auth_method == 'psk' %}
+  rightid=@{{ otherhost }}
 {%     endif %}
   ikev2={{ __vpn_ikev2 }}
 {%     if 'auto' in tunnel %}

--- a/templates/libreswan-host-to-host.secrets.j2
+++ b/templates/libreswan-host-to-host.secrets.j2
@@ -6,12 +6,8 @@
 {%       if host == inventory_hostname or host == ansible_host %}
 {%         for otherhost, otherval in __vpn_psks[__vpn_idx][host].items() %}
 {%           if otherhost == item.item %}
-{%             if tunnel.hosts[otherhost] is mapping and 'hostname' in tunnel.hosts[otherhost] %}
-{%               set otherhost = tunnel.hosts[otherhost].hostname %}
-{%             endif %}
-{%             if tunnel.hosts[host] is mapping and 'hostname' in tunnel.hosts[host] %}
-{%               set host = tunnel.hosts[host].hostname %}
-{%             endif %}
+{%             set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
+{%             set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
 @{{ host }} @{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
 {%           endif %}
 {%         endfor %}
@@ -22,12 +18,8 @@
 {%     for host, val in tunnel.hosts.items() %}
 {%       if host == inventory_hostname or host == ansible_host %}
 {%         set cert_name = tunnel.hosts[host].cert_name %}
-{%         if 'hostname' in tunnel.hosts[host] %}
-{%           set host = tunnel.hosts[host].hostname %}
-{%         endif %}
-{%         if tunnel.hosts[otherhost] is mapping and 'hostname' in tunnel.hosts[otherhost] %}
-{%           set otherhost = tunnel.hosts[otherhost].hostname %}
-{%         endif %}
+{%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
+{%         set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
 @{{ host }} @{{ otherhost }} : RSA "{{ cert_name }}"
 {%       endif %}
 {%     endfor %}


### PR DESCRIPTION
Resolves #14.

Changes `leftid`/`rightid` values to reflect the following values in order of preference (1) resolvable user-specified `hostname` (2) `ansible_host` (3) `host` key value. The connection name also synchronizes with the values in `leftid`/`rightid`.