### PR TITLE
Bugfix/leftid ip for certs

### DIFF
--- a/templates/libreswan-host-to-host.conf.j2
+++ b/templates/libreswan-host-to-host.conf.j2
@@ -7,9 +7,7 @@
 {%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 conn {{ (tunnel | json_query('name')) | ternary((tunnel.name | d('', true)) + '-', '') }}{{ host }}-to-{{ otherhost }}
   left={{ host }}
-{%         if tunnel.auth_method == 'cert' and not host | ipaddr %}
-  leftid=@{{ host }}
-{%         endif %}
+  leftid={{ (not host | ipaddr) | ternary('@','') }}{{ host }}
 {%         if tunnel.hosts[host] is mapping and 'subnets' in tunnel.hosts[host] %}
   leftsubnets={
 {%-          for subnet in tunnel.hosts[host].subnets -%}
@@ -22,7 +20,7 @@ conn {{ (tunnel | json_query('name')) | ternary((tunnel.name | d('', true)) + '-
 {%     endfor %}
   right={{ otherhost }}
 {%     if tunnel.auth_method == 'psk' %}
-  rightid=@{{ otherhost }}
+  rightid={{ (not otherhost | ipaddr) | ternary('@','') }}{{ otherhost }}
 {%     endif %}
 {%     if tunnel.hosts[item] is mapping and 'subnets' in tunnel.hosts[item] %}
   rightsubnets={

--- a/templates/libreswan-host-to-host.conf.j2
+++ b/templates/libreswan-host-to-host.conf.j2
@@ -7,7 +7,7 @@
 {%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 conn {{ (tunnel | json_query('name')) | ternary((tunnel.name | d('', true)) + '-', '') }}{{ host }}-to-{{ otherhost }}
   left={{ host }}
-  leftid={{ (not host | ipaddr) | ternary('@','') }}{{ host }}
+  leftid={{ host | ipaddr | ternary('','@') }}{{ host }}
 {%         if tunnel.hosts[host] is mapping and 'subnets' in tunnel.hosts[host] %}
   leftsubnets={
 {%-          for subnet in tunnel.hosts[host].subnets -%}
@@ -20,7 +20,7 @@ conn {{ (tunnel | json_query('name')) | ternary((tunnel.name | d('', true)) + '-
 {%     endfor %}
   right={{ otherhost }}
 {%     if tunnel.auth_method == 'psk' %}
-  rightid={{ (not otherhost | ipaddr) | ternary('@','') }}{{ otherhost }}
+  rightid={{ otherhost | ipaddr | ternary('','@') }}{{ otherhost }}
 {%     endif %}
 {%     if tunnel.hosts[item] is mapping and 'subnets' in tunnel.hosts[item] %}
   rightsubnets={

--- a/templates/libreswan-host-to-host.conf.j2
+++ b/templates/libreswan-host-to-host.conf.j2
@@ -7,7 +7,9 @@
 {%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 conn {{ (tunnel | json_query('name')) | ternary((tunnel.name | d('', true)) + '-', '') }}{{ host }}-to-{{ otherhost }}
   left={{ host }}
+{%         if tunnel.auth_method == 'cert' and not host | ipaddr %}
   leftid=@{{ host }}
+{%         endif %}
 {%         if tunnel.hosts[host] is mapping and 'subnets' in tunnel.hosts[host] %}
   leftsubnets={
 {%-          for subnet in tunnel.hosts[host].subnets -%}

--- a/templates/libreswan-host-to-host.secrets.j2
+++ b/templates/libreswan-host-to-host.secrets.j2
@@ -8,7 +8,7 @@
 {%           if otherhost == item.item %}
 {%             set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 {%             set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
-{{ (not host | ipaddr) | ternary('@','') }}{{ host }} {{ (not otherhost | ipaddr) | ternary('@','') }}{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
+{{ host | ipaddr | ternary('','@') }}{{ host }} {{ otherhost | ipaddr | ternary('','@') }}{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
 {%           endif %}
 {%         endfor %}
 {%       endif %}
@@ -20,7 +20,7 @@
 {%         set cert_name = tunnel.hosts[host].cert_name | d((hostvars[host] | d({})).cert_name) %}
 {%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 {%         set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
-{{ (not host | ipaddr) | ternary('@','') }}{{ host }} {{ (not otherhost | ipaddr) | ternary('@','') }}{{ otherhost }} : RSA "{{ cert_name }}"
+{{ host | ipaddr | ternary('','@') }}{{ host }} {{ otherhost | ipaddr | ternary('','@') }}{{ otherhost }} : RSA "{{ cert_name }}"
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/templates/libreswan-host-to-host.secrets.j2
+++ b/templates/libreswan-host-to-host.secrets.j2
@@ -8,7 +8,7 @@
 {%           if otherhost == item.item %}
 {%             set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 {%             set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
-@{{ host }} @{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
+{{ (not host | ipaddr) | ternary('@','') }}{{ host }} {{ (not otherhost | ipaddr) | ternary('@','') }}{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
 {%           endif %}
 {%         endfor %}
 {%       endif %}
@@ -20,7 +20,7 @@
 {%         set cert_name = tunnel.hosts[host].cert_name | d((hostvars[host] | d({})).cert_name) %}
 {%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 {%         set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
-@{{ host }} @{{ otherhost }} : RSA "{{ cert_name }}"
+{{ (not host | ipaddr) | ternary('@','') }}{{ host }} {{ (not otherhost | ipaddr) | ternary('@','') }}{{ otherhost }} : RSA "{{ cert_name }}"
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/tests/tests_host_to_unmanaged_host.yml
+++ b/tests/tests_host_to_unmanaged_host.yml
@@ -71,7 +71,7 @@
             __vpn_register_unmanaged_conf.content | b64decode is not
             search('right=' + __vpn_unmanaged_hostname) or
             __vpn_register_unmanaged_conf.content | b64decode is not
-            search('rightid=@' + __vpn_unmanaged_hostname)
+            search('rightid=' + __vpn_unmanaged_hostname)
 
         - name: assert success for unmanaged host conf file
           assert:
@@ -87,7 +87,7 @@
           set_fact:
             __vpn_success: false
           when: >-
-            __vpn_register_unmanaged_secrets.content | b64decode is not search('^@' + __vpn_main_hostname + ' @' + __vpn_unmanaged_hostname + ' : PSK *')
+            __vpn_register_unmanaged_secrets.content | b64decode is not search('^@' + __vpn_main_hostname + ' ' + __vpn_unmanaged_hostname + ' : PSK *')
 
         - name: assert success for unmanaged host secrets files
           assert:


### PR DESCRIPTION
Fixes #19.

Whenever a valid IP address is found in the `leftid` or `rightid` fields, an `@` will not be prepended to that value.