### PR TITLE
use wait_for_connection instead of wait_for with ssh

### DIFF
--- a/tasks/enable_restart_vpn.yml
+++ b/tasks/enable_restart_vpn.yml
@@ -9,10 +9,6 @@
   loop: "{{ __vpn_services }}"
 
 - name: Wait for ssh connection to return
-  wait_for:
-    host: "{{ ansible_default_ipv4.address |\
-          d(ansible_default_ipv6.address) }}"
-    port: 22
+  wait_for_connection:
     delay: 3
-    state: started
-  delegate_to: localhost
+    timeout: 300


### PR DESCRIPTION
The check using `wait_for` to check the ssh port does not work
reliably with qemu based testing, because the IP address inside
the VM is not always resolvable externally, and the port number
is different from `22` as well.  Instead, use the `wait_for_connection`
module which explicitly tests that Ansible can connection to the
host using its transport mechanism, which I think is what this
check is trying to do.