### PR TITLE
use custom vpn_ipaddr filter

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.8.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.8.2"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ['2.7', '3.6', '3.7', '3.8', '3.9']
+        pyver: ['2.7', '3.6', '3.8', '3.9']
     steps:
       - name: checkout PR
         uses: actions/checkout@v2

--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -1,0 +1,2 @@
+plugins/filter/vpn_ipaddr.py no-unicode-literals!skip
+tests/vpn/unit/test_vpn_ipaddr.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.11.txt
+++ b/.sanity-ansible-ignore-2.11.txt
@@ -1,0 +1,2 @@
+plugins/filter/vpn_ipaddr.py no-unicode-literals!skip
+tests/vpn/unit/test_vpn_ipaddr.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,0 +1,2 @@
+plugins/filter/vpn_ipaddr.py no-unicode-literals!skip
+tests/vpn/unit/test_vpn_ipaddr.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,0 +1,2 @@
+plugins/filter/vpn_ipaddr.py no-unicode-literals!skip
+tests/vpn/unit/test_vpn_ipaddr.py no-unicode-literals!skip

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These global variables should be applied to the configuration for every tunnel (
 | vpn\_regen\_keys                     | Whether pre-shared keys should be regenerated for sets of hosts with existing keys.                | bool        | no       | false                   |
 | vpn\_opportunistic                   | Whether an opportunistic mesh configuration should be used.                                        | bool        | no       | false                   |
 | vpn\_default\_policy                 | The default policy group to add target machines to under a mesh configuration.                | str         | no       | `private-or-clear`      |
+| [vpn\_ensure\_openssl](#vpn_ensure_openssl)    | Ensure the `openssl` package is installed on the controller.                          | bool        | no       | true      |
 | [vpn\_connections](#vpn_connections) | List of VPN connections to make.                                                              | list        | yes      | -                       |
 
 ### vpn_auth_method
@@ -45,6 +46,12 @@ The value specified in this variable will determine the value of the `authby` fi
 Acceptable values:
 * `psk` for pre-shared key (PSK) authentication
 * `cert` for authentication using certificates
+
+### vpn_ensure_openssl
+
+The role uses `openssl` to generate PSKs.  It requires this to be installed on the controller node.
+The default value is `true`.  If you have pre-generated your PSKs, or you are not using PSKs, then
+set `vpn_ensure_openssl: false`.
 
 ### vpn_connections
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,9 @@ The role will set up a vpn tunnel between each pair of hosts in the list of `vpn
 
 ## Requirements
 
-The Ansible controller requires the python `netaddr` package.
-
-See `meta/requirements.yml` for the requirements.  You must install the
-requirements before using this role:
-```
-ansible-galaxy collection install -vv -r meta/requirements.yml
-```
-See
-https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#using-meta-requirements-yml
-for more information.
+The Ansible controller requires the python `ipaddress` package on EL7 systems,
+or other systems that use python 2.7.  On python 3.x systems, the VPN role
+uses the python3 built-in `ipaddress` module.
 
 ## Top-level variables
 

--- a/ansible_pytest_extra_requirements.txt
+++ b/ansible_pytest_extra_requirements.txt
@@ -2,5 +2,3 @@
 
 # ansible and dependencies for all supported platforms
 ansible ; python_version > "2.6"
-idna<2.8 ; python_version < "2.7"
-PyYAML<5.1 ; python_version < "2.7"

--- a/filter_plugins/vpn_ipaddr.py
+++ b/filter_plugins/vpn_ipaddr.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# (c) 2014, Maciej Delmanowski <drybjed@gmail.com>
+# (c) 2021, Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was copied from https://github.com/ansible-collections/ansible.netcommon/blob/ea48d0a5b8130bdba3361b5e3f758b552240ef58/plugins/filter/ipaddr.py
+
+# Make coding more python3-ish
+# Converted from ansible.netcommon to use ipaddress instead of netaddr
+# need unicode_literals for ipaddress on python2 - otherwise get errors like this:
+# ValueError: '192.168.122.1' does not appear to be an IPv4 or IPv6 interface
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+__metaclass__ = type
+
+from ansible.utils.display import Display
+from functools import partial
+import types
+
+ipaddress = None
+try:
+    import ipaddress
+
+except ImportError:
+    ipaddress = None
+    # in this case, we'll make the filters return error messages (see bottom)
+
+from ansible import errors
+
+display = Display()
+
+
+# ---- IP address and network query helpers ----
+def ip_interface(value):
+    return ipaddress.ip_interface(value)
+
+
+def ip_int_to_network(value, version):
+    if not version:
+        return ipaddress.ip_interface(value)
+    elif version == 4:
+        return ipaddress.IPv4Interface(value)
+    else:  # assume 6
+        return ipaddress.IPv6Interface(value)
+
+
+def ip_num_cidr_to_network(value):
+    # this section will raise an exception if value
+    # is not a string with a "/", or if the parts of
+    # the string are not ints
+    address, prefix = value.split("/")
+    address = int(address)
+    prefix = int(prefix)
+    return ip_interface((address, prefix))
+
+
+def _empty_ipaddr_query(v, vtype):
+    # We don't have any query to process, so just check what type the user
+    # expects, and return the IP address in a correct format
+    if v:
+        if vtype == "address":
+            return str(v.ip)
+        elif vtype == "network":
+            return str(v)
+
+
+def _bool_ipaddr_query(v):
+    if v:
+        return True
+
+
+def is_single_host(v):
+    # see if the given network has only 1 address
+    # assume that means it is a single host
+    return v.network.num_addresses == 1
+
+
+def _cidr_lookup_query(v, net, value):
+    if hasattr(net.network, "supernet_of"):
+        if net.network.supernet_of(v.network):
+            return value
+    elif not is_single_host(v):
+        if (
+            net.network.network_address <= v.network.network_address
+            and net.network.broadcast_address >= v.network.broadcast_address
+        ):
+            return value
+    elif v.ip in net.network:
+        return value
+    return False
+
+
+def _network_query(v):
+    """Return the network of a given IP or subnet"""
+    return str(v.network.network_address)
+
+
+def _subnet_query(v):
+    return str(v.network)
+
+
+def _version_query(v):
+    return v.version
+
+
+# ---- IP address and network filters ----
+
+
+def ipaddr(value, query="", version=False, alias="ipaddr"):
+    """Check if string is an IP address or network and filter it"""
+
+    query_func_extra_args = {
+        "": ("vtype",),
+        "cidr_lookup": ("net", "value"),
+    }
+
+    query_func_map = {
+        "": _empty_ipaddr_query,
+        "bool": _bool_ipaddr_query,
+        "cidr_lookup": _cidr_lookup_query,
+        "network": _network_query,
+        "subnet": _subnet_query,
+        "version": _version_query,
+    }
+
+    vtype = None
+
+    # Check if value is a list and parse each element
+    if isinstance(value, (list, tuple, types.GeneratorType)):
+        _ret = [ipaddr(element, str(query), version) for element in value]
+        return [item for item in _ret if item]
+
+    elif not value or value is True:
+        # TODO: Remove this check in a major version release of collection with porting guide
+        # TODO: and raise exception commented out below
+        display.warning(
+            "The value '%s' is not a valid IP address or network, passing this value to ipaddr filter"
+            " might result in breaking change in future." % value
+        )
+        return False
+        # raise errors.AnsibleFilterError(
+        #     "{0!r} is not a valid IP address or network".format(value)
+        # )
+
+    # Check if value is a number and convert it to an IP address
+    elif str(value).isdigit():
+        try:
+            v = ip_int_to_network(value, version)
+        except Exception:
+            return False
+        # We got an IP address, let's mark it as such
+        value = str(v)
+        vtype = "address"
+
+    # value has not been recognized, check if it's a valid IP string
+    else:
+        try:
+            v = ip_interface(value)
+
+            # value is a valid IP string, check if user specified
+            # CIDR prefix or just an IP address, this will indicate default
+            # output format
+            try:
+                address, prefix = value.split("/")
+                vtype = "network"
+            except Exception:
+                vtype = "address"
+
+        # value hasn't been recognized, maybe it's a numerical CIDR?
+        except Exception:
+            try:
+                v = ip_num_cidr_to_network(value)
+            except Exception:
+                return False
+
+            # We have a valid CIDR, so let's write it in correct format
+            value = str(v)
+            vtype = "network"
+
+    # We have a query string but it's not in the known query types. Check if
+    # that string is a valid subnet, if so, we can check later if given IP
+    # address/network is inside that specific subnet
+    try:
+        if (
+            query
+            and (query not in query_func_map or query == "cidr_lookup")
+            and not str(query).isdigit()
+            and ipaddr(query, "network")
+        ):
+            net = ip_interface(query)
+            query = "cidr_lookup"
+    except Exception:
+        pass
+
+    # This code checks if value maches the IP version the user wants, ie. if
+    # it's any version ("ipaddr()"), IPv4 ("ipv4()") or IPv6 ("ipv6()")
+    # If version does not match, return False
+    if version and v.version != version:
+        return False
+
+    extras = []
+    for arg in query_func_extra_args.get(query, tuple()):
+        extras.append(locals()[arg])
+    try:
+        return query_func_map[query](  # pylint: disable=no-value-for-parameter
+            v, *extras
+        )
+    except KeyError:
+        try:
+            int(query)
+            if v.network.num_addresses == 1:
+                if vtype == "address":
+                    return str(v.ip)
+                elif vtype == "network":
+                    return str(v)
+
+            elif v.network.num_addresses > 1:
+                try:
+                    return str(v.network[int(query)]) + "/" + str(v.network.prefixlen)
+                except Exception:
+                    return False
+
+            else:
+                return value
+
+        except Exception:
+            raise errors.AnsibleFilterError(alias + ": unknown filter type: %s" % query)
+
+    return False
+
+
+def _need_ipaddress(f_name, *args, **kwargs):
+    raise errors.AnsibleFilterError(
+        "The %s filter requires python 3.3 or later with built-in ipaddress "
+        "module, or python's ipaddress be installed on the ansible controller" % f_name
+    )
+
+
+# ---- Ansible filters ----
+class FilterModule(object):
+    """IP address and network manipulation filters
+
+    Detailed documentation available at https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters_ipaddr.html
+    This module implements only the 'ipaddr' filter called 'vpn_ipaddr', and only provides a small subset of that
+    functionality required for the vpn role.
+    """
+
+    filter_map = {
+        "vpn_ipaddr": ipaddr,
+    }
+
+    def filters(self):
+        if ipaddress:
+            return self.filter_map
+        else:
+            return dict((f, partial(_need_ipaddress, f)) for f in self.filter_map)

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,2 +1,0 @@
-collections:
-  - name: ansible.netcommon

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -2,6 +2,9 @@
 
 # Write extra requirements for running pytest here:
 # If you need ansible then uncomment the following line:
-#-ransible_pytest_extra_requirements.txt
+-ransible_pytest_extra_requirements.txt
 # If you need mock then uncomment the following line:
 #mock ; python_version < "3.0"
+# EL7 uses 1.0.16 or later of ipaddress
+ipaddress==1.0.16 ; python_version < "3.0"
+# otherwise - use ipaddress built into python

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,18 @@
 
 - name: Controller tasks
   block:
+    - name: List packages on the controller to see if OpenSSL is installed
+      package_facts:
+      when: vpn_ensure_openssl | d(true)
+
+    - name: Ensure OpenSSL is installed on the controller
+      package:
+        name: openssl
+        state: present
+      when:
+        - vpn_ensure_openssl | d(true)
+        - "'openssl' not in ansible_facts.packages"
+
     - name: Enforce default auth method as needed
       set_fact:
         vpn_connections: |

--- a/tasks/mesh_conf.yml
+++ b/tasks/mesh_conf.yml
@@ -14,7 +14,7 @@
 
 - name: Set net CIDR fact
   set_fact:
-    current_subnet: "{{ ip_with_prefix_register.stdout | ipaddr('subnet') }}"
+    current_subnet: "{{ ip_with_prefix_register.stdout | vpn_ipaddr('subnet') }}"
 
 - name: Set policies fact
   set_fact:
@@ -32,7 +32,7 @@
       {% for node in ansible_play_hosts %}
       {%   set node_in_pol = {'flag': false} %}
       {%   for policy in policies %}
-      {%     if hostvars[node].current_ip | ipaddr(policy.cidr) | ipaddr('bool') %}
+      {%     if hostvars[node].current_ip | vpn_ipaddr(policy.cidr) | vpn_ipaddr('bool') %}
       {%       if node_in_pol.update({'flag': true}) %}{% endif %}
       {%     endif %}
       {%   endfor %}

--- a/templates/libreswan-host-to-host.conf.j2
+++ b/templates/libreswan-host-to-host.conf.j2
@@ -7,7 +7,7 @@
 {%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 conn {{ tunnel.name ~ '-' if 'name' in tunnel and tunnel.name else '' }}{{ host }}-to-{{ otherhost }}
   left={{ host }}
-  leftid={{ host | ipaddr | ternary('','@') }}{{ host }}
+  leftid={{ host | vpn_ipaddr | ternary('','@') }}{{ host }}
 {%         if tunnel.hosts[host] is mapping and 'subnets' in tunnel.hosts[host] %}
   leftsubnets={
 {%-          for subnet in tunnel.hosts[host].subnets -%}
@@ -20,7 +20,7 @@ conn {{ tunnel.name ~ '-' if 'name' in tunnel and tunnel.name else '' }}{{ host 
 {%     endfor %}
   right={{ otherhost }}
 {%     if tunnel.auth_method == 'psk' %}
-  rightid={{ otherhost | ipaddr | ternary('','@') }}{{ otherhost }}
+  rightid={{ otherhost | vpn_ipaddr | ternary('','@') }}{{ otherhost }}
 {%     endif %}
 {%     if tunnel.hosts[item] is mapping and 'subnets' in tunnel.hosts[item] %}
   rightsubnets={

--- a/templates/libreswan-host-to-host.secrets.j2
+++ b/templates/libreswan-host-to-host.secrets.j2
@@ -8,7 +8,7 @@
 {%           if otherhost == item.item %}
 {%             set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 {%             set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
-{{ host | ipaddr | ternary('','@') }}{{ host }} {{ otherhost | ipaddr | ternary('','@') }}{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
+{{ host | vpn_ipaddr | ternary('','@') }}{{ host }} {{ otherhost | vpn_ipaddr | ternary('','@') }}{{ otherhost }} : PSK "{{ otherval['pre_shared_key'] }}"
 {%           endif %}
 {%         endfor %}
 {%       endif %}
@@ -20,7 +20,7 @@
 {%         set cert_name = tunnel.hosts[host].cert_name | d((hostvars[host] | d({})).cert_name) %}
 {%         set host = tunnel.hosts[host].hostname | d((hostvars[host] | d({})).ansible_host | d(host)) %}
 {%         set otherhost = tunnel.hosts[otherhost].hostname | d((hostvars[otherhost] | d({})).ansible_host | d(otherhost)) %}
-{{ host | ipaddr | ternary('','@') }}{{ host }} {{ otherhost | ipaddr | ternary('','@') }}{{ otherhost }} : RSA "{{ cert_name }}"
+{{ host | vpn_ipaddr | ternary('','@') }}{{ host }} {{ otherhost | vpn_ipaddr | ternary('','@') }}{{ otherhost }} : RSA "{{ cert_name }}"
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/tests/roles/linux-system-roles.vpn/filter_plugins
+++ b/tests/roles/linux-system-roles.vpn/filter_plugins
@@ -1,0 +1,1 @@
+../../../filter_plugins

--- a/tests/unit/test_vpn_ipaddr.py
+++ b/tests/unit/test_vpn_ipaddr.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was copied from https://github.com/ansible-collections/ansible.netcommon/blob/ea48d0a5b8130bdba3361b5e3f758b552240ef58/tests/unit/plugins/filter/test_ipaddr.py  # noqa: E501
+
+# Make coding more python3-ish
+# need unicode_literals for ipaddress on python2 - otherwise get errors like this:
+# ValueError: '192.168.122.1' does not appear to be an IPv4 or IPv6 interface
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+__metaclass__ = type
+
+import unittest
+
+import vpn_ipaddr as ipaddr
+
+
+class TestIpFilter(unittest.TestCase):
+    def test_ipaddr_empty_query(self):
+        self.assertEqual(ipaddr.ipaddr("192.0.2.230"), "192.0.2.230")
+        self.assertEqual(ipaddr.ipaddr("192.0.2.230/30"), "192.0.2.230/30")
+        self.assertEqual(ipaddr.ipaddr([]), [])
+
+        self.assertEqual(ipaddr.ipaddr(True), False)
+        self.assertEqual(ipaddr.ipaddr(""), False)
+
+        # #TODO: Add these test after the check value check for None and True is removed
+        # #TODO: from ipaddr filter
+        # with pytest.raises(
+        #     AnsibleFilterError,
+        #     match="True is not a valid IP address or network",
+        # ):
+        #     ipaddr.ipaddr(True)
+        # with pytest.raises(
+        #     AnsibleFilterError, match="'' is not a valid IP address or network"
+        # ):
+        #     ipaddr.ipaddr("")
+
+    def test_ipaddr_bool_query(self):
+        self.assertTrue(ipaddr.ipaddr("192.0.2.20", "bool"))
+        self.assertFalse(ipaddr.ipaddr("192.900.2.20", "bool"))
+
+    def test_network(self):
+        address = "1.12.1.34/32"
+        self.assertEqual(ipaddr.ipaddr(address, "network"), "1.12.1.34")
+        address = "1.12.1.34/255.255.255.255"
+        self.assertEqual(ipaddr.ipaddr(address, "network"), "1.12.1.34")
+        address = "1.12.1.34"
+        self.assertEqual(ipaddr.ipaddr(address, "network"), "1.12.1.34")
+        address = "1.12.1.35/31"
+        self.assertEqual(ipaddr.ipaddr(address, "network"), "1.12.1.34")
+        address = "1.12.1.34/24"
+        self.assertEqual(ipaddr.ipaddr(address, "network"), "1.12.1.0")
+
+    def test_cidr_lookup(self):
+        big_network = "1.12.1.0/24"
+        small_network = "1.12.1.0/28"
+        ip_in_big = "1.12.1.192"
+        ip_not_in_big = "192.168.122.1"
+        # test identity - x contains x
+        self.assertTrue(ipaddr.ipaddr(big_network, big_network))
+        self.assertTrue(ipaddr.ipaddr(small_network, small_network))
+        self.assertTrue(ipaddr.ipaddr(ip_in_big, ip_in_big))
+        self.assertTrue(ipaddr.ipaddr(ip_not_in_big, ip_not_in_big))
+        # test ip containment - X contains y
+        self.assertTrue(ipaddr.ipaddr(ip_in_big, big_network))
+        self.assertTrue(ipaddr.ipaddr(small_network, big_network))
+        # test not contained - X does not contain a
+        self.assertFalse(ipaddr.ipaddr(ip_not_in_big, big_network))
+        self.assertFalse(ipaddr.ipaddr(ip_not_in_big, small_network))
+        self.assertFalse(ipaddr.ipaddr(ip_in_big, small_network))
+        self.assertFalse(ipaddr.ipaddr(big_network, small_network))
+        self.assertFalse(ipaddr.ipaddr(big_network, ip_in_big))
+        self.assertFalse(ipaddr.ipaddr(small_network, ip_in_big))
+
+    def test_subnet(self):
+        address = "1.12.1.34/29"
+        self.assertEqual(ipaddr.ipaddr(address, "subnet"), "1.12.1.32/29")
+        address = "1.12.1.34/32"
+        self.assertEqual(ipaddr.ipaddr(address, "subnet"), "1.12.1.34/32")
+        address = "1.12.1.34/23"
+        self.assertEqual(ipaddr.ipaddr(address, "subnet"), "1.12.0.0/23")

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,3 @@ lsr_enable = true
 
 [lsr_ansible-lint]
 configfile = {toxinidir}/.ansible-lint
-
-[lsr_pylint]
-configfile = {toxinidir}/pylintrc
-
-[qemu_common]
-deps = netaddr


### PR DESCRIPTION
Use a custom vpn_ipaddr filter which uses the `ipaddress` module.  This is built-in to python3.  Users will need to install `ipaddress` on python 2 controllers.  All versions of EL7 include the `python-ipaddress` package.
This is based on the ansible.netcommon.ipaddr filter, but with most
of the functionality removed except that which is necessary for
the VPN role.