### PR TITLE
System Roles should consistently use ansible_managed in configuration files it manages

### DIFF
--- a/tasks/mesh_conf.yml
+++ b/tasks/mesh_conf.yml
@@ -46,11 +46,11 @@
       {{ policies | unique }}
 
 - name: Write tunnel policies for each network
-  lineinfile:
-    dest: "/etc/ipsec.d/policies/{{ item.policy }}"
-    line: "{{ lookup('template', 'policy.j2') }}"
+  template:
+    src: 'policy.j2'
+    dest: "/etc/ipsec.d/policies/{{ item }}"
     mode: '0644'
-  loop: "{{ policies }}"
+  loop: "{{ policies | map(attribute='policy') | unique | list }}"
   notify:
     - __vpn_handler_enable_start_vpn
     - __vpn_handler_init_mesh_conns

--- a/templates/libreswan-host-to-host.conf.j2
+++ b/templates/libreswan-host-to-host.conf.j2
@@ -1,4 +1,5 @@
 #jinja2: lstrip_blocks: True
+{{ ansible_managed | comment }}
 {% for tunnel in vpn_connections %}
 {%   if item in tunnel.hosts %}
 {%     set otherhost = tunnel.hosts[item].hostname | d((hostvars[item] | d({})).ansible_host | d(item)) %}

--- a/templates/libreswan-host-to-host.secrets.j2
+++ b/templates/libreswan-host-to-host.secrets.j2
@@ -1,4 +1,5 @@
 #jinja2: lstrip_blocks: True
+{{ ansible_managed | comment }}
 {% for tunnel in vpn_connections %}
 {%   set __vpn_idx = loop.index0 %}
 {%   if tunnel.auth_method == 'psk' %}

--- a/templates/libreswan-mesh.conf.j2
+++ b/templates/libreswan-mesh.conf.j2
@@ -1,4 +1,5 @@
 #jinja2: lstrip_blocks: True
+{{ ansible_managed | comment }}
 conn private
       type=tunnel
       left=%defaultroute

--- a/templates/policy.j2
+++ b/templates/policy.j2
@@ -1,1 +1,6 @@
-{{ item.cidr }}
+{{ ansible_managed | comment }}
+{% for policy in policies %}
+{%   if policy.policy == item %}
+{{ policy.cidr }}
+{%   endif %}
+{% endfor %}

--- a/tests/tests_host_to_host_cert.yml
+++ b/tests/tests_host_to_host_cert.yml
@@ -92,7 +92,10 @@
           set_fact:
             __vpn_success: false
           when: >-
-            item.content | b64decode is not search('@' + __vpn_main_hostname + ' @host0' + (idx+1)|string + '\.local : RSA \"' + __vpn_main_certname + '\"')
+            item.content | b64decode |
+            regex_search('^@' + __vpn_main_hostname + ' @host0' +
+            (idx+1)|string + '\.local : RSA \"' + __vpn_main_certname + '\"',
+            multiline=True) | d() | length == 0
           loop: '{{ __vpn_register_secrets.results }}'
           loop_control:
             index_var: idx

--- a/tests/tests_host_to_host_psk.yml
+++ b/tests/tests_host_to_host_psk.yml
@@ -77,9 +77,10 @@
           set_fact:
             __vpn_success: false
           when: >-
-            item.content | b64decode is not
-            search('^@' + __vpn_main_hostname + ' @host0' +
-            (idx+1)|string + '\.local : PSK *')
+            item.content | b64decode |
+            regex_search('^@' + __vpn_main_hostname + ' @host0' +
+            (idx+1)|string + '\.local : PSK .*',
+            multiline=True) | d() | length == 0
           loop: '{{ __vpn_register_secrets.results }}'
           loop_control:
             index_var: idx

--- a/tests/tests_host_to_unmanaged_host.yml
+++ b/tests/tests_host_to_unmanaged_host.yml
@@ -87,7 +87,10 @@
           set_fact:
             __vpn_success: false
           when: >-
-            __vpn_register_unmanaged_secrets.content | b64decode is not search('^@' + __vpn_main_hostname + ' ' + __vpn_unmanaged_hostname + ' : PSK *')
+            __vpn_register_unmanaged_secrets.content | b64decode |
+            regex_search('^@' + __vpn_main_hostname + ' ' +
+            __vpn_unmanaged_hostname + ' : PSK *',
+            multiline=True) | d() | length == 0
 
         - name: assert success for unmanaged host secrets files
           assert:


### PR DESCRIPTION
bz#2044640

Commented files by tests_mesh_cert.yml:
```
==> /etc/ipsec.d/mesh.conf <==
#
# Ansible managed
#
conn private
      type=tunnel
      left=%defaultroute

==> /etc/ipsec.d/policies/clear <==
#
# Ansible managed
#
198.51.100.0/24

==> /etc/ipsec.d/policies/private <==
#
# Ansible managed
#
203.0.113.0/24

==> /etc/ipsec.d/policies/private-or-clear <==
#
# Ansible managed
#
10.0.2.0/24

169.254.0.0/16
```