### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__vpn_required_facts) == __vpn_required_facts
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vpn_vars_file }}"
   loop:

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.vpn
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __vpn_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -4,3 +4,4 @@
 
   roles:
     - linux-system-roles.vpn
+  gather_facts: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,3 +8,10 @@ __vpn_services:
 __vpn_ikev2: 'insist'
 
 __vpn_nss_location: '/var/lib/ipsec/nss'
+#
+# ansible_facts required by the role
+__vpn_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.