### PR TITLE
gather network facts default_ipv4 default_ipv6

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure ansible_facts used by role
   setup:
-    gather_subset: min
+    gather_subset: network
   when: not ansible_facts.keys() | list |
     intersect(__vpn_required_facts) == __vpn_required_facts
 

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,4 +1,5 @@
 - hosts: all
+  gather_facts: true
   tasks:
     - name: create var file in caller that can override the one in called role
       delegate_to: localhost

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,6 +11,8 @@ __vpn_nss_location: '/var/lib/ipsec/nss'
 #
 # ansible_facts required by the role
 __vpn_required_facts:
+  - default_ipv4
+  - default_ipv6
   - distribution
   - distribution_major_version
   - distribution_version


### PR DESCRIPTION
Gather fact subset `network` instead of `min`
Ensure facts `default_ipv4` and `default_ipv6`
Ensure all tests work when using ANSIBLE_GATHERING=explicit
