### PR TITLE
Version 1.3.5 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 Changelog
 =========
 
+[1.3.5] - 2022-07-19
+--------------------
+
+### New Features
+
+- none
+
+### Bug Fixes
+
+- none
+
+### Other Changes
+
+- gather network facts default_ipv4 default_ipv6 (#56)
+
+Gather fact subset `network` instead of `min`
+Ensure facts `default_ipv4` and `default_ipv6`
+Ensure all tests work when using ANSIBLE_GATHERING=explicit
+
+- make min_ansible_version a string in meta/main.yml (#57)
+
+The Ansible developers say that `min_ansible_version` in meta/main.yml
+must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
+
+- Add CHANGELOG.md (#58)
+
 [1.3.4] - 2022-05-06
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ Changelog
 
 - gather network facts default_ipv4 default_ipv6 (#56)
 
-Gather fact subset `network` instead of `min`
-Ensure facts `default_ipv4` and `default_ipv6`
-Ensure all tests work when using ANSIBLE_GATHERING=explicit
+    * Gather fact subset `network` instead of `min`
+    * Ensure facts `default_ipv4` and `default_ipv6`
+    * Ensure all tests work when using ANSIBLE_GATHERING=explicit
 
 - make min_ansible_version a string in meta/main.yml (#57)
 


### PR DESCRIPTION
[1.3.5] - 2022-07-19
--------------------

### New Features

- none

### Bug Fixes

- none

### Other Changes

- gather network facts default_ipv4 default_ipv6 (#56)

Gather fact subset `network` instead of `min`
Ensure facts `default_ipv4` and `default_ipv6`
Ensure all tests work when using ANSIBLE_GATHERING=explicit

- make min_ansible_version a string in meta/main.yml (#57)

The Ansible developers say that `min_ansible_version` in meta/main.yml
must be a `string` value like `"2.9"`, not a `float` value like `2.9`.

- Add CHANGELOG.md (#58)

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
