### PR TITLE
Use the firewall role and the selinux role from the vpn role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,11 @@ vpn_regen_keys: false
 vpn_opportunistic: false
 vpn_connections: []
 vpn_default_policy: private-or-clear
+
+# If true, manage the IPsec ports, 500/UDP, 4500/UDP, and 4500/TCP
+# using# the firewall role.
+vpn_manage_firewall: false
+
+# If true, manage the IPsec ports, 500/UDP, 4500/UDP, and 4500/TCP
+# using# the selinux role.
+vpn_manage_selinux: false

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+collections:
+  - fedora.linux_system_roles

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure the vpn ports status with the firewall role
+  include_role:
+    name: fedora.linux_system_roles.firewall
+  vars:
+    firewall:
+      - {'service': 'ipsec', 'state': 'enabled'}
+  when:
+    - vpn_manage_firewall | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,12 @@
     state: present
   tags: packages
 
+- name: Configure firewall
+  include_tasks: firewall.yml
+
+- name: Configure selinux
+  include_tasks: selinux.yml
+
 - name: Controller tasks
   block:
     # NOTE: Trying to accomplish this without using sudo on the controller

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Populate service facts
+  service_facts:
+
+- block:
+    - name: Get the ipsec tcp service ports
+      shell: |-
+        set -euo pipefail
+        firewall-cmd --info-service=ipsec | \
+          egrep "^ +ports: +" | sed -e "s/ *ports: //"
+      register: __ports
+      changed_when: false
+
+    - name: Initialize _vpn_selinux
+      set_fact:
+        _vpn_selinux: []
+
+    - name: Add the ipsec service ports to _vpn_selinux
+      set_fact:
+        _vpn_selinux: "{{ _vpn_selinux +
+            [{'ports': _pair[0], 'proto': _pair[1], 'setype': 'ipsecnat_port_t',
+              'state': 'present', 'local': true}] }}"
+      vars:
+        _pair: "{{ item.split('/') | list }}"
+      loop: "{{ __ports.stdout.split(' ') }}"
+
+    - name: Ensure the service and the ports status with the selinux role
+      include_role:
+        name: fedora.linux_system_roles.selinux
+      vars:
+        selinux_ports: "{{ _vpn_selinux }}"
+  when:
+    - '"firewalld.service" in ansible_facts.services'
+    - ansible_facts.services["firewalld.service"]["state"] == "running"
+    - vpn_manage_selinux | bool

--- a/tests/tasks/check_firewall_selinux.yml
+++ b/tests/tasks/check_firewall_selinux.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+---
+- block:
+    - name: Get firewall service
+      command: firewall-cmd --list-services
+      register: _result
+      changed_when: false
+
+    - name: Ensure 'ipsec' is in the firewalld service list
+      assert:
+        that:
+          - "'ipsec' in _result.stdout"
+
+    - name: Get associated selinux ports
+      shell: |-
+        set -euo pipefail
+        firewall-cmd --info-service=ipsec | \
+          egrep "^ +ports: +" | sed -e "s/ *ports: //"
+      register: __ports
+      changed_when: false
+
+    - name: Check associated selinux ports when vpn_manage_selinux is true
+      shell: |-
+        set -euo pipefail
+        semanage port --list -C | grep ipsecnat_port_t | \
+          grep "{{ pair[0] }}" | grep "{{ pair[1] }}"
+      changed_when: false
+      vars:
+        pair: "{{ item.split('/') }}"
+      loop: "{{ __ports.stdout.split(' ') }}"
+      when: vpn_manage_selinux | bool
+
+  when:
+    - '"firewalld.service" in ansible_facts.services'
+    - ansible_facts.services["firewalld.service"]["state"] == "running"

--- a/tests/tests_defaults_vars.yml
+++ b/tests/tests_defaults_vars.yml
@@ -15,3 +15,6 @@
             - vpn_auth_method
             - vpn_regen_keys
             - vpn_connections
+
+        - name: check the firewall and the selinux port status
+          include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_host_to_host_cert.yml
+++ b/tests/tests_host_to_host_cert.yml
@@ -37,6 +37,7 @@
         - name: Use vpn role
           include_role:
             name: linux-system-roles.vpn
+            public: true
 
         - name: Assert file existence
           include_tasks: tasks/assert_conf_secrets_files_exist.yml
@@ -104,3 +105,6 @@
           assert:
             that: __vpn_success | d(false)
             msg: Found errors in .secrets files
+
+        - name: check the firewall and the selinux port status
+          include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_host_to_host_psk.yml
+++ b/tests/tests_host_to_host_psk.yml
@@ -8,6 +8,8 @@
 
   vars:
     __vpn_num_hosts: 2
+    # test to set true to manage selinux only
+    vpn_manage_selinux: true
 
   tasks:
 
@@ -28,6 +30,7 @@
         - name: Use vpn role
           include_role:
             name: linux-system-roles.vpn
+            public: true
 
         - name: Assert file existence
           include_tasks: tasks/assert_conf_secrets_files_exist.yml
@@ -91,3 +94,6 @@
           assert:
             that: __vpn_success | d(false)
             msg: Found errors in .conf files
+
+        - name: check the firewall and the selinux port status
+          include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_host_to_host_psk_custom.yml
+++ b/tests/tests_host_to_host_psk_custom.yml
@@ -65,6 +65,7 @@
         - name: Use vpn role
           include_role:
             name: linux-system-roles.vpn
+            public: true
 
         - name: Assert file existence
           include_tasks: tasks/assert_conf_secrets_files_exist.yml
@@ -148,3 +149,6 @@
           assert:
             that: __vpn_success | d(false)
             msg: Found errors in .conf files
+
+        - name: check the firewall and the selinux port status
+          include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_host_to_unmanaged_host.yml
+++ b/tests/tests_host_to_unmanaged_host.yml
@@ -30,6 +30,7 @@
         - name: Use vpn role
           include_role:
             name: linux-system-roles.vpn
+            public: true
 
         - name: stat unmanaged host conf file path
           stat:
@@ -96,3 +97,6 @@
           assert:
             that: __vpn_success | d(false)
             msg: Found errors in .secrets file for unmanaged host
+
+        - name: check the firewall and the selinux port status
+          include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_mesh_cert.yml
+++ b/tests/tests_mesh_cert.yml
@@ -11,6 +11,8 @@
     # see RFC 5737, the following CIDRs are provided for documentation/testing use
     __vpn_private_host_cidr: "203.0.113.0/24"
     __vpn_clear_host_cidr: "198.51.100.0/24"
+    # test to set true to manage firewall only
+    vpn_manage_firewall: true
 
   tasks:
 
@@ -44,6 +46,7 @@
         - name: Use vpn role
           include_role:
             name: linux-system-roles.vpn
+            public: true
           ignore_errors: true
 
         - meta: flush_handlers
@@ -196,3 +199,6 @@
           assert:
             that: __vpn_success | d(false)
             msg: Found errors policies/clear file
+
+        - name: check the firewall and the selinux port status
+          include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_subnet_to_subnet.yml
+++ b/tests/tests_subnet_to_subnet.yml
@@ -12,6 +12,8 @@
       - '192.0.2.0/24'
       - '198.51.100.0/24'
       - '203.0.113.0/24'
+    vpn_manage_firewall: true
+    vpn_manage_selinux: true
 
   tasks:
 
@@ -33,6 +35,7 @@
         - name: Use vpn role
           include_role:
             name: linux-system-roles.vpn
+            public: true
 
         - name: Assert file existence
           include_tasks: tasks/assert_conf_secrets_files_exist.yml
@@ -61,3 +64,6 @@
           assert:
             that: __vpn_success | d(false)
             msg: Found errors in .conf files
+
+        - name: check the firewall and the selinux port status
+          include_tasks: tasks/check_firewall_selinux.yml


### PR DESCRIPTION
- Introduce vpn_manage_firewall to use the firewall role to manage the ipsec service. vpn_manage_firewall is set to true, by default. If the variable is set to false, the firewall configuration is disabled.

- Introduce vpn_manage_selinux to use the selinux role to manage the ports defined in the firewall ipsec service. vpn_manage_selinux is set to true, by default.  If the variable is set to false, the selinux configuration is disabled.

- Add the test check task check_firewall_selinux.yml for verify the ports status.

- Add meta/collection-requirements.yml