### PR TITLE
only check for firewall ipsec service if managing firewall

### DIFF
--- a/tests/tasks/check_firewall_selinux.yml
+++ b/tests/tasks/check_firewall_selinux.yml
@@ -31,5 +31,6 @@
       when: vpn_manage_selinux | bool
 
   when:
+    - vpn_manage_firewall or vpn_manage_selinux
     - '"firewalld.service" in ansible_facts.services'
     - ansible_facts.services["firewalld.service"]["state"] == "running"


### PR DESCRIPTION
Some systems use `firewalld` by default.  We should only expect the
`ipsec` service is present if the test tells the vpn role to manage
firewall or selinux.
