### PR TITLE
Add check for non-inclusive language

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,14 +91,11 @@ become=true - so just use "exists" test to check for /usr/bin/openssl
 
 - Fix a bash bug in changelog_to_tag.yml, which unexpectedly expanded "*" (#62)
 
-- changelog_to_tag action - support other than "master" for the main branch name, as well (#63)
+- changelog_to_tag action - github action ansible test improvements
 
 - Use GITHUB_REF_NAME as name of push branch; fix error in branch detection [citest skip] (#64)
 
 We need to get the name of the branch to which CHANGELOG.md was pushed.
-For now, it looks as though `GITHUB_REF_NAME` is that name.  But don't
-trust it - first, check that it is `main` or `master`.  If not, then use
-a couple of other methods to determine what is the push branch.
 
 [1.3.5] - 2022-07-19
 --------------------
@@ -273,7 +270,7 @@ must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
 ### Other Changes
 
 - Remove python-26 environment from tox testing
-- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker
+- update to tox-lsr 2.4.0 - add support for ansible-test with docker
 - CI: Add support for RHEL-9
 
 [1.0.0] - 2021-02-11

--- a/tests/tasks/add_hosts.yml
+++ b/tests/tasks/add_hosts.yml
@@ -3,9 +3,9 @@
   add_host:
     name: "{{ 'host%02x.local' | format(item) }}"
     groups: testing
-    cert_name: "{{ __vpn_dynamic_hosts_dummy_cert }}"
-    current_ip: "{{ __vpn_dynamic_hosts_dummy_ip }}"
-    current_subnet: "{{ __vpn_dynamic_hosts_dummy_cidr }}"
+    cert_name: "{{ __vpn_dynamic_hosts_sample_cert }}"
+    current_ip: "{{ __vpn_dynamic_hosts_sample_ip }}"
+    current_subnet: "{{ __vpn_dynamic_hosts_sample_cidr }}"
   loop: "{{ range(1,__vpn_num_hosts+1)|list }}"
 
 - name: create mock vpn_connections

--- a/tests/tasks/setup_test.yml
+++ b/tests/tasks/setup_test.yml
@@ -11,9 +11,9 @@
       set_fact:
         inventory_hostname: "{{ __vpn_main_hostname }}"
 
-    # Dummy main host is dynamically added to avoid error in VPN role
+    # Sample main host is dynamically added to avoid error in VPN role
     # that says hostvars[{{ main_hostname }}] is undefined
-    - name: add dummy main host
+    - name: add sample main host
       add_host:
         name: "{{ __vpn_main_hostname }}"
 
@@ -34,27 +34,27 @@
 - name: Dynamically add more hosts
   include_tasks: tasks/add_hosts.yml
 
-- name: create dummy policies directory
+- name: create sample policies directory
   block:
-    - name: Create dummy policies directory for testing
+    - name: Create sample policies directory for testing
       file:
         path: "/etc/ipsec.d/policies"
         state: directory
         mode: '0600'
 
-    - name: Create dummy policy files for testing
+    - name: Create sample policy files for testing
       file:
         path: "/etc/ipsec.d/policies/private"
         state: touch
         mode: "0600"
 
-    - name: Create dummy policy files for testing
+    - name: Create sample policy files for testing
       file:
         path: "/etc/ipsec.d/policies/private-or-clear"
         state: touch
         mode: "0600"
 
-    - name: Create dummy policy files for testing
+    - name: Create sample policy files for testing
       file:
         path: "/etc/ipsec.d/policies/clear"
         state: touch

--- a/tests/tests_mesh_cert.yml
+++ b/tests/tests_mesh_cert.yml
@@ -181,7 +181,7 @@
             __vpn_register_private_or_clear['content'] | b64decode
             is not search(current_subnet) or
             __vpn_register_private_or_clear['content'] | b64decode
-            is not search(__vpn_dynamic_hosts_dummy_cidr)
+            is not search(__vpn_dynamic_hosts_sample_cidr)
 
         - name: assert success for policy private or clear file
           assert:

--- a/tests/vars/main.yml
+++ b/tests/vars/main.yml
@@ -3,7 +3,7 @@
 
 __vpn_main_hostname: "mainhost.local"
 
-# dummy vars to use for dynamically generated hosts
-__vpn_dynamic_hosts_dummy_ip: "169.254.1.1"
-__vpn_dynamic_hosts_dummy_cidr: "169.254.0.0/16"
-__vpn_dynamic_hosts_dummy_cert: "dyn_cert"
+# sample vars to use for dynamically generated hosts
+__vpn_dynamic_hosts_sample_ip: "169.254.1.1"
+__vpn_dynamic_hosts_sample_cidr: "169.254.0.0/16"
+__vpn_dynamic_hosts_sample_cert: "dyn_cert"


### PR DESCRIPTION

Add a check for usage of terms and language that is considered
non-inclusive. We are using the woke tool for this with a wordlist
that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

Clean up non-inclusive words.
- CHANGELOG.md
- tests/tasks/add_hosts.yml
- tests/tasks/setup_test.yml
- tests/tests_mesh_cert.yml
- tests/vars/main.yml