### PR TITLE
Fix issues found by CodeQL

### DIFF
--- a/filter_plugins/vpn_ipaddr.py
+++ b/filter_plugins/vpn_ipaddr.py
@@ -74,11 +74,17 @@ def _empty_ipaddr_query(v, vtype):
             return str(v.ip)
         elif vtype == "network":
             return str(v)
+        else:
+            return None
+    else:
+        return None
 
 
 def _bool_ipaddr_query(v):
     if v:
         return True
+    else:
+        return None
 
 
 def is_single_host(v):
@@ -202,6 +208,7 @@ def ipaddr(value, query="", version=False, alias="ipaddr"):
             net = ip_interface(query)
             query = "cidr_lookup"
     except Exception:
+        # We will check the query below.
         pass
 
     # This code checks if value maches the IP version the user wants, ie. if


### PR DESCRIPTION
filter_plugins/vpn_ipaddr.py
- 'except' clause does nothing but pass and there is no explanatory comment.
- Mixing implicit and explicit returns may indicate an error as implicit returns always return None.

Signed-off-by: Noriko Hosoi <nhosoi@redhat.com>