### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/libreswan-host-to-host.conf.j2
+++ b/templates/libreswan-host-to-host.conf.j2
@@ -1,5 +1,6 @@
 #jinja2: lstrip_blocks: True
 {{ ansible_managed | comment }}
+{{ "system_role:vpn" | comment(prefix="", postfix="") }}
 {% for tunnel in vpn_connections %}
 {%   if item in tunnel.hosts %}
 {%     set otherhost = tunnel.hosts[item].hostname | d((hostvars[item] | d({})).ansible_host | d(item)) %}

--- a/templates/libreswan-host-to-host.secrets.j2
+++ b/templates/libreswan-host-to-host.secrets.j2
@@ -1,5 +1,6 @@
 #jinja2: lstrip_blocks: True
 {{ ansible_managed | comment }}
+{{ "system_role:vpn" | comment(prefix="", postfix="") }}
 {% for tunnel in vpn_connections %}
 {%   set __vpn_idx = loop.index0 %}
 {%   if tunnel.auth_method == 'psk' %}

--- a/templates/libreswan-mesh.conf.j2
+++ b/templates/libreswan-mesh.conf.j2
@@ -1,5 +1,6 @@
 #jinja2: lstrip_blocks: True
 {{ ansible_managed | comment }}
+{{ "system_role:vpn" | comment(prefix="", postfix="") }}
 conn private
       type=tunnel
       left=%defaultroute

--- a/templates/policy.j2
+++ b/templates/policy.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:vpn" | comment(prefix="", postfix="") }}
 {% for policy in policies %}
 {%   if policy.policy == item %}
 {{ policy.cidr }}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:VPN
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.