### PR TITLE
ansible-lint - use changed_when for conditional tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,3 +8,4 @@
   loop: "{{ ansible_play_batch }}"
   when: item != inventory_hostname
   listen: __vpn_handler_init_mesh_conns
+  changed_when: false


### PR DESCRIPTION
ansible-lint now requires the use of changed_when even for
conditional tasks

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
