### PR TITLE
ci: update tox-lsr to version 3.0.0

### DIFF
--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.


### PR DESCRIPTION
The major version bump is because tox-lsr 3 drops support
for tox version 2.  If you are using tox 2 you will need to
upgrade to tox 3 or 4.

tox-lsr 3.0.0 adds support for tox 4, commitlint, and ansible-lint-collection

See https://github.com/linux-system-roles/tox-lsr/releases/tag/3.0.0
for full release notes

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
