### PR TITLE
ci: ansible-lint - skip var-naming[read-only]

### DIFF
--- a/tests/tasks/setup_test.yml
+++ b/tests/tasks/setup_test.yml
@@ -10,6 +10,7 @@
   block:
     - name: Change inventory_hostname
       set_fact:
+        # noqa var-naming[read-only]
         inventory_hostname: "{{ __vpn_main_hostname }}"
 
     # Sample main host is dynamically added to avoid error in VPN role


### PR DESCRIPTION
Error: This special variable is read-only. (inventory_hostname) (set_fact: inventory_hostname)
var-naming[read-only]: This special variable is read-only. (inventory_hostname) (set_fact: inventory_hostname)

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
