### PR TITLE
tests: add cleanup after each test

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,7 +1,11 @@
 ---
 - name: Ensure that the role runs with default parameters
   hosts: all
-
   roles:
     - linux-system-roles.vpn
+  post_tasks:
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup
   gather_facts: false

--- a/tests/tests_defaults_vars.yml
+++ b/tests/tests_defaults_vars.yml
@@ -17,3 +17,8 @@
 
     - name: Check the firewall and the selinux port status
       include_tasks: tasks/check_firewall_selinux.yml
+
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup

--- a/tests/tests_host_to_host_cert.yml
+++ b/tests/tests_host_to_host_cert.yml
@@ -110,3 +110,8 @@
         loop_var: __file_content
       vars:
         __fingerprint: "system_role:vpn"
+
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup

--- a/tests/tests_host_to_host_psk.yml
+++ b/tests/tests_host_to_host_psk.yml
@@ -91,3 +91,8 @@
 
     - name: Check the firewall and the selinux port status
       include_tasks: tasks/check_firewall_selinux.yml
+
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup

--- a/tests/tests_host_to_host_psk_custom.yml
+++ b/tests/tests_host_to_host_psk_custom.yml
@@ -147,3 +147,8 @@
 
     - name: Check the firewall and the selinux port status
       include_tasks: tasks/check_firewall_selinux.yml
+
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup

--- a/tests/tests_host_to_unmanaged_host.yml
+++ b/tests/tests_host_to_unmanaged_host.yml
@@ -94,3 +94,8 @@
 
     - name: Check the firewall and the selinux port status
       include_tasks: tasks/check_firewall_selinux.yml
+
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup

--- a/tests/tests_mesh_cert.yml
+++ b/tests/tests_mesh_cert.yml
@@ -209,3 +209,8 @@
         loop_var: __file_content
       vars:
         __fingerprint: "system_role:vpn"
+
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup

--- a/tests/tests_subnet_to_subnet.yml
+++ b/tests/tests_subnet_to_subnet.yml
@@ -61,3 +61,8 @@
 
     - name: Check the firewall and the selinux port status
       include_tasks: tasks/check_firewall_selinux.yml
+
+    - name: Cleanup
+      include_tasks: tasks/cleanup.yml
+      tags:
+        - tests::cleanup


### PR DESCRIPTION
tests now run in an environment where the managed node is reused
so tests should clean up after

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
