### PR TITLE
test: stop firewall after tests that use firewall

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -51,3 +51,9 @@
         state: absent
         path: "/etc/ipsec.d/{{ inventory_hostname }}-to-{{ item }}.secrets"
       with_items: "{{ tunnels }}"
+
+- name: Stop firewall
+  service:
+    name: firewalld
+    state: stopped
+  when: vpn_manage_firewall | bool


### PR DESCRIPTION
Tests that use the firewall must stop the firewall after the
test is complete to ensure the firewall will not cause problems
with subsequent tests of other roles.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
