### PR TITLE
tests: for vpn_connections, use specific nodes instead of all

### DIFF
--- a/tests/tasks/add_hosts.yml
+++ b/tests/tasks/add_hosts.yml
@@ -13,7 +13,7 @@
     vpn_connections: |
       {% set vpn_connections = [] %}
       {% set myhosts = {} %}
-      {% for host in groups['all'] %}
+      {% for host in (ansible_play_batch + groups['testing'] + [inventory_hostname]) | unique %}
       {%   if '/' in host %}
       {%     set _ = myhosts.__setitem__(__vpn_main_hostname, "") %}
       {%   else %}


### PR DESCRIPTION
Our ci runs tests with inventory that lists multiple nodes and limits the execution to a single node with `--limit <node>`. Tests should consider this and only use specific nodes when building inventories.