### PR TITLE
refactor: disable ansible-lint invalid jinja error

### DIFF
--- a/tests/tests_host_to_host_cert.yml
+++ b/tests/tests_host_to_host_cert.yml
@@ -25,6 +25,8 @@
     # need extra task file to iterate over hosts per tunnel
     - name: Add cert options to check
       set_fact:
+        # not really invalid - see https://github.com/ansible/ansible-lint/issues/4702
+        # noqa jinja[invalid]
         __new_vpn_connections: "{{ __new_vpn_connections | d([]) + [item | combine(fixed_item)] | list }}"
       loop: "{{ vpn_connections }}"
       loop_control:

--- a/tests/tests_mesh_cert.yml
+++ b/tests/tests_mesh_cert.yml
@@ -20,6 +20,8 @@
 
     - name: Add extra options to check
       set_fact:
+        # not really invalid - see https://github.com/ansible/ansible-lint/issues/4702
+        # noqa jinja[invalid]
         __new_vpn_connections: "{{ __new_vpn_connections | d([]) + [item | combine(new_tunnel)] | list }}"
       loop: "{{ vpn_connections }}"
       vars:


### PR DESCRIPTION
Not really invalid
see https://github.com/ansible/ansible-lint/issues/4702

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Suppress false-positive invalid Jinja lint errors in test playbooks by adding noqa directives per ansible-lint issue #4702

Enhancements:
- Disable jinja[invalid] rule in host-to-host certificate tests by adding “# noqa jinja[invalid]” comments
- Disable jinja[invalid] rule in mesh certificate tests by adding “# noqa jinja[invalid]” comments