### PR TITLE
ci: use codecov @v6 [citest_skip]

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -92,4 +92,4 @@ jobs:
           TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6


### PR DESCRIPTION
use latest version of codecov @v6

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Bump Codecov GitHub Action in the Python unit test workflow from v5 to v6 for coverage uploads.