### PR TITLE
feat: new variable `vpn_secure_logging` defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ The firewall must be configured to allow traffic on 500/UDP, 4500/UDP, and 4500/
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----:|:--------:|---------|
 | vpn_manage_firewall | If true, enable the IPsec ports, 500/UDP, 4500/UDP, and 4500/TCP for the IKE, ESP, and AH protocols using the firewall role. If false, the `vpn role` does not manage the firewall.                | bool | no       | false    |
 | vpn_manage_selinux  | If true, manage the IPsec ports, 500/UDP, 4500/UDP, and 4500/TCP using the selinux role. If false, the `vpn role` does not manage the selinux.                                                     | bool | no       | false    |
+| vpn_secure_logging  | If true, suppress potentially sensitive output from tasks that handle credentials, secrets, and other sensitive data. Set to false for debugging issues with credential handling or secret management, but be aware this may expose sensitive information in logs. | bool | no       | true     |
 
 NOTE: The firewall configuration is prerequisite for managing selinux. If the
 firewall is not installed, managing selinux policy is skipped.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,7 @@ vpn_manage_firewall: false
 # If true, manage the IPsec ports, 500/UDP, 4500/UDP, and 4500/TCP
 # using# the selinux role.
 vpn_manage_selinux: false
+
+# If true, suppress potentially sensitive output from tasks that
+# handle credentials, secrets, and other sensitive data.
+vpn_secure_logging: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
             else {} }}"
         _host_item: "{{ {'hosts': _hosts} if _hosts | length > 0 else {} }}"
         _host: "{{ {inventory_hostname: ''} }}"
-      no_log: true
+      no_log: "{{ vpn_secure_logging }}"
 
     # any tunnel definition that is not an opportunistic tunnel should have
     # hosts defined and not be empty
@@ -107,7 +107,7 @@
       loop_control:
         loop_var: tunnel
         index_var: tunnel_idx
-      no_log: true
+      no_log: "{{ vpn_secure_logging }}"
 
 # The run_once host might not be the first one in hostvars - we do not have
 # a good way to know which host in hostvars was the run_once, and it might
@@ -115,7 +115,7 @@
 # So, find the values for the first hostvars that has __vpn_psks set
 # and use that value.
 - name: Set psks for hosts
-  no_log: true
+  no_log: "{{ vpn_secure_logging }}"
   vars:
     __vpn_psk_hostvars: "{{ hostvars.values() | selectattr('__vpn_psks', 'defined') | first }}"
   set_fact:
@@ -143,7 +143,7 @@
       loop: "{{ tunnels }}"
 
     - name: Create ipsec.secrets files
-      no_log: true
+      no_log: "{{ vpn_secure_logging }}"
       template:
         src: "{{ vpn_provider }}-host-to-host.secrets.j2"
         dest: "/etc/ipsec.d/{{ inventory_hostname }}-to-{{ item.item }}.secrets"
@@ -159,7 +159,7 @@
   loop: "{{ __vpn_connections_fixed }}"
   loop_control:
     loop_var: conn
-  no_log: true
+  no_log: "{{ vpn_secure_logging }}"
 
 - name: Record role success fingerprint
   sr_fingerprint:

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -2,6 +2,7 @@
 ---
 - name: Populate service facts
   service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Manage SELinux
   when:

--- a/tasks/vpn_get_psks_for_tunnel.yml
+++ b/tasks/vpn_get_psks_for_tunnel.yml
@@ -13,9 +13,9 @@
       loop: "{{ tunnel.hosts | d({}) | dict2items | flatten | map(attribute='key') | combinations(2) | list }}"
       vars:
         pre_shared_key: "{{ tunnel.shared_key_content | d(lookup('lines', 'openssl rand -base64 48')) }}"
-      no_log: true
+      no_log: "{{ vpn_secure_logging }}"
 
     - name: Generate PSKs or use provided shared_key_content
       set_fact:
         __vpn_psks: "{{ __vpn_psks | d({}) | combine({tunnel_idx: __vpn_host_pairs}) }}"
-      no_log: true
+      no_log: "{{ vpn_secure_logging }}"


### PR DESCRIPTION
Feature: Introduce the `vpn_secure_logging` variable that defaults to `true` and using verbosity-based logging for facts modules.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues. Additionally, service_facts produces verbose output that clutters logs during normal operation.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ vpn_secure_logging }}", allowing users to set vpn_secure_logging: false for debugging while maintaining secure defaults (true)
  - service_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - New variable vpn_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce configurable secure logging for VPN role tasks and adjust service facts logging verbosity.

New Features:
- Add vpn_secure_logging variable to control logging of tasks handling credentials and other sensitive data.

Enhancements:
- Apply vpn_secure_logging to existing sensitive tasks to allow temporarily enabling logging for debugging while keeping secure defaults.
- Make service_facts output conditional on Ansible verbosity to reduce log noise in normal operation.

Documentation:
- Document the vpn_secure_logging variable and its security/debugging trade-offs in the README.