### PR TITLE
docs(changelog): version 1.8.0 [citest_skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -801,6 +801,16 @@ manage the selinux.</td>
 <td style="text-align: center;">no</td>
 <td>false</td>
 </tr>
+<tr>
+<td>vpn_secure_logging</td>
+<td>If true, suppress potentially sensitive output from tasks that
+handle credentials, secrets, and other sensitive data. Set to false for
+debugging issues with credential handling or secret management, but be
+aware this may expose sensitive information in logs.</td>
+<td style="text-align: center;">bool</td>
+<td style="text-align: center;">no</td>
+<td>true</td>
+</tr>
 </tbody>
 </table>
 <p>NOTE: The firewall configuration is prerequisite for managing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.8.0] - 2026-05-07
+--------------------
+
+### New Features
+
+- feat: new variable `vpn_secure_logging` defaulting to `true` (#253)
+
+### Other Changes
+
+- ci: Bump actions/github-script from 8 to 9 (#252)
+
 [1.7.0] - 2026-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.8.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update documentation for the 1.8.0 release.

Documentation:
- Document the new vpn_secure_logging variable and its default behavior in the README.
- Record the 1.8.0 release notes, including the new vpn_secure_logging feature and CI dependency bump, in the changelog.